### PR TITLE
Fix and modernize GitHub CI Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - name: Run Tests with All Features
         run: cargo test --all-features
       - name: Run Tests with No Default Features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   check:
-    name: Check
+    name: Check (stable)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,43 +1,30 @@
+name: Continuous Integration
+
+# Runs for each commit/PR, but not tag push
 on:
   push:
     branches:
-    - master
-  pull_request: {}
+      - "**"
+  pull_request:
 
-name: Continuous integration
+env:
+  CARGO_TERM_COLOR: always
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   check:
     name: Check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
+      - name: Run Check
+        run: cargo check
 
-  test-versions:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-  test-features:
+  test-suite:
     name: Test Suite
     runs-on: ubuntu-latest
     strategy:
@@ -47,72 +34,45 @@ jobs:
           - beta
           - nightly
           - 1.39.0
+          - 1.88.0
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
         with:
           toolchain: ${{ matrix.rust }}
           override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
+      - name: Run Tests with All Features
+        run: cargo test --all-features
+      - name: Run Tests with No Default Features
+        run: cargo test --no-default-features
 
-  test-os:
-    name: Test Suite
+  test-suite-os:
+    name: Test Suite (stable)
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
+      - name: Run Test
+        run: cargo test
 
   fmt:
-    name: Rustfmt
+    name: Rustfmt (stable)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Run Rustfmt
+        run: cargo fmt --all -- --check
 
   clippy:
-    name: Clippy
+    name: Clippy (stable)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust:
-          - stable
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1.9.0
+      - name: Run Clippy
+        run: cargo clippy -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "indenter"
 version = "0.3.3"
+rust-version = "1.39"
 authors = ["Jane Lusby <jlusby@yaah.dev>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@
     rust_2018_idioms,
     unreachable_pub,
     bad_style,
-    const_err,
     dead_code,
     improper_ctypes,
     non_shorthand_field_patterns,
@@ -106,8 +105,9 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_in_public,
+    private_interfaces,
     unconditional_recursion,
+    unnameable_types,
     unused,
     unused_allocation,
     unused_comparisons,
@@ -167,10 +167,10 @@ pub type Inserter = dyn FnMut(usize, &mut dyn fmt::Write) -> fmt::Result;
 impl Format<'_> {
     fn insert_indentation(&mut self, line: usize, f: &mut dyn fmt::Write) -> fmt::Result {
         match self {
-            Format::Uniform { indentation } => write!(f, "{}", indentation),
+            Format::Uniform { indentation } => write!(f, "{indentation}"),
             Format::Numbered { ind } => {
                 if line == 0 {
-                    write!(f, "{: >4}: ", ind)
+                    write!(f, "{ind: >4}: ")
                 } else {
                     write!(f, "      ")
                 }
@@ -219,7 +219,7 @@ where
                 self.needs_indent = false;
             }
 
-            self.inner.write_fmt(format_args!("{}", line))?;
+            self.inner.write_fmt(format_args!("{line}"))?;
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,9 +105,7 @@
     overflowing_literals,
     path_statements,
     patterns_in_fns_without_body,
-    private_interfaces,
     unconditional_recursion,
-    unnameable_types,
     unused,
     unused_allocation,
     unused_comparisons,
@@ -167,10 +165,10 @@ pub type Inserter = dyn FnMut(usize, &mut dyn fmt::Write) -> fmt::Result;
 impl Format<'_> {
     fn insert_indentation(&mut self, line: usize, f: &mut dyn fmt::Write) -> fmt::Result {
         match self {
-            Format::Uniform { indentation } => write!(f, "{indentation}"),
+            Format::Uniform { indentation } => write!(f, "{}", indentation),
             Format::Numbered { ind } => {
                 if line == 0 {
-                    write!(f, "{ind: >4}: ")
+                    write!(f, "{: >4}: ", ind)
                 } else {
                     write!(f, "      ")
                 }
@@ -219,7 +217,7 @@ where
                 self.needs_indent = false;
             }
 
-            self.inner.write_fmt(format_args!("{line}"))?;
+            self.inner.write_fmt(format_args!("{}", line))?;
         }
 
         Ok(())


### PR DESCRIPTION
You can see the results of a successful run here: https://github.com/nullstalgia/eyre-indenter/actions/runs/16245429504

The following lints have been removed from the `warn()` directive:

`private_in_public`: Replaced by new, on-by-default, [type privacy](https://rust-lang.github.io/rfcs/2145-type-privacy.html#lints) warnings.

`const_err`: [Deprecated](https://github.com/rust-lang/rust/issues/71800), now returns a hard error.

The `missing_doc_code_examples` lint being renamed to `rustdoc::missing_doc_code_examples` means I can't put a global `RUSTFLAGS: -Dwarnings`, unless I add the `rustversion` build-dep, but I wanted to avoid adding any dependencies.

At the very least, the `stable` clippy run does run with `-D warnings`.